### PR TITLE
Increase document buffer size

### DIFF
--- a/src/WebThingAdapter.cpp
+++ b/src/WebThingAdapter.cpp
@@ -293,7 +293,7 @@ void WebThingAdapter::handleThing(AsyncWebServerRequest *request,
   AsyncResponseStream *response =
       request->beginResponseStream("application/json");
 
-  DynamicJsonDocument buf(LARGE_JSON_DOCUMENT_SIZE);
+  DynamicJsonDocument buf(10 * LARGE_JSON_DOCUMENT_SIZE);
   JsonObject descr = buf.to<JsonObject>();
   device->serialize(descr, ip, port);
 


### PR DESCRIPTION
The document buffer is too small, meaning that for long descriptions, actions and properties are dropped.  This extends the document buffer 10x.